### PR TITLE
change: include legacy, drop commonjs, other changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run test --if-present
-    - run: npm run build --if-present
-      env:
-        STAGE: local
-        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-        AWS_REGION: ${{ secrets.AWS_REGION }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@
 /configuration.sh
 /fiddle.js
 
-# globbed things
-globbed-*.js
-
 # built things
-/dist
+/default
+/legacy

--- a/.idea/noddity-micromark-renderer.iml
+++ b/.idea/noddity-micromark-renderer.iml
@@ -5,6 +5,8 @@
       <excludeFolder url="file://$MODULE_DIR$/temp" />
       <excludeFolder url="file://$MODULE_DIR$/.tmp" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/default" />
+      <excludeFolder url="file://$MODULE_DIR$/legacy" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Change categories are:
 ### Removed
 ### Security
 
+## [2.0.0](https://github.com/saibotsivad/noddity-micromark-renderer/compare/v1.1.0...v2.0.0) - 2023-08-09
+### Changed
+- No longer supporting CommonJS exports, it's all *the future* now.
+- It's not bundled anymore either, as that got a bit complicated. I might bundle it again later, all these dependencies are no fun to install.
+- Lots of the function signatures changed. They weren't well documented, but now hopefully the documentation is better, and more logical.
+
 ## [1.1.0](https://github.com/saibotsivad/noddity-micromark-renderer/compare/v1.0.1...v1.1.0) - 2023-06-22
 ### Added
 - You can call the `loadFile` with an additional `options` object, which gets passed along to your non-Markdown renderer, merged into the overall options.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Noddity Micromark Renderer
 
-This is a re-work of Noddity that uses Micromark and mdast to render the Markdown content, and has *no opinion* about non-Markdown content.
+This is a re-work of Noddity that uses Micromark and mdast to render the Markdown content, and has no opinion about non-Markdown content.
 
-(See the [demo](./example/demo-renderer.js) for an example of using Ractive, Nodditys built-in template renderer.)
+Included is a legacy renderer, if you want to use classic Noddity syntax and the legacy Ractive renderer. (See the [demo](./example/demo-renderer.js) for an example of it.)
 
 ## Install
 
@@ -34,6 +34,21 @@ const NODDITY_FOLDER = '/path/to/noddity/content'
 const DOMAIN = 'my-site.com'
 ```
 
+If you're using the legacy renderer, which uses Ractive, you don't need nearly as much:
+
+```js
+import { noddityRenderer } from 'noddity-micromark-renderer/legacy'
+const render = noddityRenderer({
+	directory: NODDITY_FOLDER,
+	domain: 'site.com',
+	pathPrefix: '#!/',
+	pagePathPrefix: 'post/',
+	name: 'My Cool Website',
+})
+```
+
+## API of non-legacy `noddityRenderer`
+
 Each input property is defined here:
 
 #### loadFile
@@ -50,11 +65,16 @@ const loadFile = async filename => readFile(join(NODDITY_FOLDER, filename), 'utf
 
 The `options` object is passed along to your non-Markdown renderer, merged into the overall options.
 
-#### metadataParser
+#### metadataMdastMutator
 
-Typed: `(frontmatter: string): Object<*>`
+Typed: `async ({ filename: string, mdastTree: MdastTree }): void`
 
-Used by the renderer to parse the frontmatter section of each file.
+Called by the renderer to mutate the mdast (Markdown Abstract State Tree) to optionally parse the frontmatter section of each file and set it.
+
+After this is called, `mdast` should have these properties set to properly parse the remaining content:
+
+- `mdast.children[0].metadata` - This is the fully parsed file metadata, if present.
+- `mdast.children[0].position.end.offset` - This is the [unist](https://github.com/syntax-tree/unist) positional information about the character offset at the very end of the metadata, including frontmatter fence characters.
 
 If you want to use [js-yaml](https://github.com/nodeca/js-yaml) that would be (defining the schema is not required by this renderer):
 

--- a/example/demo.js
+++ b/example/demo.js
@@ -1,20 +1,18 @@
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 
-import { createCustomRenderer } from './demo-legacy-ractive-renderer.js'
+import { noddityRenderer } from '../src/legacy.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const NODDITY_DIR = join(__dirname, 'noddity')
-const DOMAIN = 'site.com'
 
-const render = createCustomRenderer({
-	noddityDirectory: NODDITY_DIR,
-	websiteDomain:DOMAIN,
+const render = noddityRenderer({
+	directory: join(__dirname, 'noddity'),
+	domain: 'site.com',
 })
 
-const out1 = await render.fromString('a [[cool.md|file]] link', 'yolo.md')
+const out1 = await render.fromString('very [[cool.md|file]] link', 'excellent.md')
 console.log('----------- HTML1 -------------')
-console.log(out1.html) // => <p>a <a href="https://site.com/#!/post/cool.md">file</a> link</p>
+console.log(out1.html) // => <p>very <a href="https://site.com/#!/post/cool.md">file</a> link</p>
 
 const out2 = await render.loadFile('example-file.md')
 console.log('----------- HTML2 -------------')

--- a/example/noddity/different
+++ b/example/noddity/different
@@ -1,0 +1,4 @@
+title: Testing passing in metadata
+markdown: false
+
+<em>{{helloName}}</em>

--- a/example/noddity/home
+++ b/example/noddity/home
@@ -1,0 +1,6 @@
+---
+title: Link that goes home
+markdown: false
+---
+
+<a href="https://{{ domain }}/">{{ this.1 }}</a>

--- a/example/noddity/img
+++ b/example/noddity/img
@@ -1,4 +1,4 @@
 title: Relative Image
 markdown: false
 
-{{#if markdownOutput && !discardImages}}![]({{this.1}}){width=15cm}{{elseif !discardImages}}<a href="{{ this.1 }}" target="_blank"><img src="{{ this.1 }}" style="max-width:{{ #if this.2 }}{{ this.2 }}{{ else }}100%{{ /if }};" height="{{ this.3 }}"></a>{{/if}}
+{{#if markdownOutput}}![]({{this.1}}){width={{#if this.2}}{{this.2}}{{else}}15cm{{/if}}}{{else}}<a href="{{ this.1 }}" target="_blank"><img src="{{ this.1 }}" style="max-width:{{ #if this.2 }}{{ this.2 }}{{ else }}100%{{ /if }};" height="{{ this.3 }}"></a>{{/if}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,7 @@
       "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "mdast-util-noddity": "^1.0.2"
-      },
-      "devDependencies": {
-        "@saibotsivad/eslint-config-saibotsivad": "*",
-        "hast-util-noddity": "^1.0.0",
+        "hast-util-noddity": "^1.0.1",
         "hast-util-raw": "^8.0.0",
         "hast-util-sanitize": "^4.1.0",
         "hast-util-to-html": "^8.0.4",
@@ -21,10 +17,14 @@
         "mdast-util-from-markdown": "^1.3.1",
         "mdast-util-frontmatter": "^1.0.1",
         "mdast-util-gfm": "^2.0.2",
+        "mdast-util-noddity": "^1.0.2",
         "mdast-util-to-hast": "^12.3.0",
         "micromark-extension-frontmatter": "^1.1.1",
         "micromark-extension-gfm": "^2.0.3",
-        "ractive": "^0.7.3",
+        "ractive": "^0.7.3"
+      },
+      "devDependencies": {
+        "@saibotsivad/eslint-config-saibotsivad": "*",
         "uvu": "^0.5.6"
       }
     },
@@ -133,7 +133,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
       "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-      "dev": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -142,7 +141,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
       "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -158,7 +156,6 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
       "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -166,20 +163,17 @@
     "node_modules/@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-      "dev": true
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
-      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
-      "dev": true
+      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "dev": true
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.30.7",
@@ -374,9 +368,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -442,8 +436,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -500,7 +493,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -527,7 +519,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -537,7 +528,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -547,7 +537,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -577,7 +566,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -609,7 +597,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -626,7 +613,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
       "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-      "dev": true,
       "dependencies": {
         "character-entities": "^2.0.0"
       },
@@ -646,7 +632,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -655,7 +640,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
       "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -690,7 +674,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -939,8 +922,7 @@
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1007,7 +989,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
       "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
-      "dev": true,
       "dependencies": {
         "format": "^0.2.0"
       },
@@ -1067,7 +1048,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -1171,7 +1151,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
       "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -1187,16 +1166,14 @@
       }
     },
     "node_modules/hast-util-noddity": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-noddity/-/hast-util-noddity-1.0.0.tgz",
-      "integrity": "sha512-0qB2ZDW5ij1eDjBaGbg5FeOPQBB40aGuk5sVu3LRrkmS8wBtqqkTKnnZ5gHjP3OR5r3LordcmF2wWQwpNg3kMw==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-noddity/-/hast-util-noddity-1.0.1.tgz",
+      "integrity": "sha512-Jj1+HODhDLpQWVkpvWUaZKRGjG29nQHsaOD15Ijtn7P4a2G9141Msrb8kQX+vTtsFOzNuBpsvcGcWJugDRWt/g=="
     },
     "node_modules/hast-util-parse-selector": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
       "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0"
       },
@@ -1209,7 +1186,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-8.0.0.tgz",
       "integrity": "sha512-bKbaUxMNLjZMMowgcrc4l3aQSPiMLiceZD+mp+AKF8Si0mtyR2DYVdxzS2XBxXYDeW/VvfZy40lNxHRiY6MMTg==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "extend": "^3.0.0",
@@ -1233,7 +1209,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-4.1.0.tgz",
       "integrity": "sha512-Hd9tU0ltknMGRDv+d6Ro/4XKzBqQnP/EZrpiTbpFYfXv/uOhWeKc+2uajcbEvAEH98VZd7eII2PiXm13RihnLw==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0"
       },
@@ -1246,7 +1221,6 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
       "integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -1269,7 +1243,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
       "integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/parse5": "^6.0.0",
@@ -1291,14 +1264,12 @@
     "node_modules/hast-util-to-html/node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/hast-util-to-parse5": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz",
       "integrity": "sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -1316,7 +1287,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
       "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -1326,7 +1296,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
       "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -1343,7 +1312,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
       "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -1408,7 +1376,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1471,7 +1438,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1497,7 +1463,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1527,7 +1492,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -1550,7 +1514,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
       "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -1560,7 +1523,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
       "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -1575,7 +1537,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
       "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "escape-string-regexp": "^5.0.0",
@@ -1591,7 +1552,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -1603,7 +1563,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
       "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -1627,7 +1586,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz",
       "integrity": "sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0",
@@ -1642,7 +1600,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
       "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
-      "dev": true,
       "dependencies": {
         "mdast-util-from-markdown": "^1.0.0",
         "mdast-util-gfm-autolink-literal": "^1.0.0",
@@ -1661,7 +1618,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
       "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "ccount": "^2.0.0",
@@ -1677,7 +1633,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
       "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0",
@@ -1692,7 +1647,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
       "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0"
@@ -1706,7 +1660,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
       "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "markdown-table": "^3.0.0",
@@ -1722,7 +1675,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
       "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0"
@@ -1741,7 +1693,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
       "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "unist-util-is": "^5.0.0"
@@ -1755,7 +1706,6 @@
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
       "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
-      "dev": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/mdast": "^3.0.0",
@@ -1775,7 +1725,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
       "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -1795,7 +1744,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
       "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dev": true,
       "dependencies": {
         "@types/mdast": "^3.0.0"
       },
@@ -1818,7 +1766,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
       "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1853,7 +1800,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
       "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1887,7 +1833,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.1.1.tgz",
       "integrity": "sha512-m2UH9a7n3W8VAH9JO9y01APpPKmNNNs71P0RbknEmYSaZU5Ghogv38BYO94AI5Xw6OYfxZRdHZZ2nYjs/Z+SZQ==",
-      "dev": true,
       "dependencies": {
         "fault": "^2.0.0",
         "micromark-util-character": "^1.0.0",
@@ -1903,7 +1848,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
       "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
-      "dev": true,
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^1.0.0",
         "micromark-extension-gfm-footnote": "^1.0.0",
@@ -1923,7 +1867,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
       "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
-      "dev": true,
       "dependencies": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-sanitize-uri": "^1.0.0",
@@ -1939,7 +1882,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
       "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
-      "dev": true,
       "dependencies": {
         "micromark-core-commonmark": "^1.0.0",
         "micromark-factory-space": "^1.0.0",
@@ -1959,7 +1901,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
       "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
-      "dev": true,
       "dependencies": {
         "micromark-util-chunked": "^1.0.0",
         "micromark-util-classify-character": "^1.0.0",
@@ -1977,7 +1918,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
       "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
-      "dev": true,
       "dependencies": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -1994,7 +1934,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
       "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
-      "dev": true,
       "dependencies": {
         "micromark-util-types": "^1.0.0"
       },
@@ -2007,7 +1946,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
       "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
-      "dev": true,
       "dependencies": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -2024,7 +1962,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
       "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2045,7 +1982,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
       "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2067,7 +2003,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
       "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2087,7 +2022,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
       "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2109,7 +2043,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
       "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2131,7 +2064,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
       "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2151,7 +2083,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
       "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2170,7 +2101,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
       "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2191,7 +2121,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
       "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2211,7 +2140,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
       "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2230,7 +2158,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
       "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2252,7 +2179,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
       "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2268,7 +2194,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
       "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2284,7 +2209,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
       "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2303,7 +2227,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
       "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2322,7 +2245,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
       "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2343,7 +2265,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
       "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2365,7 +2286,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
       "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2381,7 +2301,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
       "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -2424,7 +2343,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2432,8 +2350,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2487,7 +2404,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -2552,7 +2468,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
       "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2592,8 +2507,7 @@
     "node_modules/ractive": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/ractive/-/ractive-0.7.3.tgz",
-      "integrity": "sha512-rxt5U9VTFsRaDGtwTz0+NFpUgdWEbvMSG3k1gq5YV0bco6fEo42bPqAwj0U9ivW3JdhvZ5s3YhsTYBzedesPKA==",
-      "dev": true
+      "integrity": "sha512-rxt5U9VTFsRaDGtwTz0+NFpUgdWEbvMSG3k1gq5YV0bco6fEo42bPqAwj0U9ivW3JdhvZ5s3YhsTYBzedesPKA=="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -2673,7 +2587,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "dev": true,
       "dependencies": {
         "mri": "^1.1.0"
       },
@@ -2734,7 +2647,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2744,7 +2656,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
       "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
-      "dev": true,
       "dependencies": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -2827,7 +2738,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2900,7 +2810,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
       "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -2910,7 +2819,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
       "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -2923,7 +2831,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
       "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -2936,7 +2843,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
       "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -2949,7 +2855,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
       "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0",
@@ -2964,7 +2869,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
       "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
@@ -2988,7 +2892,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
       "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
-      "dev": true,
       "dependencies": {
         "dequal": "^2.0.0",
         "diff": "^5.0.0",
@@ -3013,7 +2916,6 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
       "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -3029,7 +2931,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
       "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "vfile": "^5.0.0"
@@ -3043,7 +2944,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
       "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-      "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
@@ -3057,7 +2957,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3107,7 +3006,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3199,7 +3097,6 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
       "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-      "dev": true,
       "requires": {
         "@types/ms": "*"
       }
@@ -3208,7 +3105,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
       "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
-      "dev": true,
       "requires": {
         "@types/unist": "*"
       }
@@ -3224,7 +3120,6 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
       "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
-      "dev": true,
       "requires": {
         "@types/unist": "*"
       }
@@ -3232,20 +3127,17 @@
     "@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-      "dev": true
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/parse5": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
-      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
-      "dev": true
+      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
     },
     "@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "dev": true
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.30.7",
@@ -3351,9 +3243,9 @@
       }
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "peer": true
     },
@@ -3398,8 +3290,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -3446,8 +3337,7 @@
     "ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "dev": true
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -3463,20 +3353,17 @@
     "character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
     },
     "character-entities-html4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "dev": true
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
     },
     "character-entities-legacy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "dev": true
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -3498,8 +3385,7 @@
     "comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "dev": true
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3524,7 +3410,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -3533,7 +3418,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
       "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-      "dev": true,
       "requires": {
         "character-entities": "^2.0.0"
       }
@@ -3548,14 +3432,12 @@
     "dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "diff": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "dev": true
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -3580,8 +3462,7 @@
     "entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -3766,8 +3647,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -3830,7 +3710,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
       "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
-      "dev": true,
       "requires": {
         "format": "^0.2.0"
       }
@@ -3876,8 +3755,7 @@
     "format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
-      "dev": true
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -3954,7 +3832,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
       "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -3966,16 +3843,14 @@
       }
     },
     "hast-util-noddity": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-noddity/-/hast-util-noddity-1.0.0.tgz",
-      "integrity": "sha512-0qB2ZDW5ij1eDjBaGbg5FeOPQBB40aGuk5sVu3LRrkmS8wBtqqkTKnnZ5gHjP3OR5r3LordcmF2wWQwpNg3kMw==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-noddity/-/hast-util-noddity-1.0.1.tgz",
+      "integrity": "sha512-Jj1+HODhDLpQWVkpvWUaZKRGjG29nQHsaOD15Ijtn7P4a2G9141Msrb8kQX+vTtsFOzNuBpsvcGcWJugDRWt/g=="
     },
     "hast-util-parse-selector": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
       "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0"
       }
@@ -3984,7 +3859,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-8.0.0.tgz",
       "integrity": "sha512-bKbaUxMNLjZMMowgcrc4l3aQSPiMLiceZD+mp+AKF8Si0mtyR2DYVdxzS2XBxXYDeW/VvfZy40lNxHRiY6MMTg==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "extend": "^3.0.0",
@@ -4004,7 +3878,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-4.1.0.tgz",
       "integrity": "sha512-Hd9tU0ltknMGRDv+d6Ro/4XKzBqQnP/EZrpiTbpFYfXv/uOhWeKc+2uajcbEvAEH98VZd7eII2PiXm13RihnLw==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0"
       }
@@ -4013,7 +3886,6 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
       "integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -4032,7 +3904,6 @@
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
           "integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
-          "dev": true,
           "requires": {
             "@types/hast": "^2.0.0",
             "@types/parse5": "^6.0.0",
@@ -4050,8 +3921,7 @@
         "parse5": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-          "dev": true
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
         }
       }
     },
@@ -4059,7 +3929,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz",
       "integrity": "sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -4072,14 +3941,12 @@
     "hast-util-whitespace": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
-      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
-      "dev": true
+      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng=="
     },
     "hastscript": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
       "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -4091,8 +3958,7 @@
     "html-void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
-      "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==",
-      "dev": true
+      "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A=="
     },
     "ignore": {
       "version": "5.2.0",
@@ -4140,8 +4006,7 @@
     "is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -4178,7 +4043,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -4200,8 +4064,7 @@
     "kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
     },
     "levn": {
       "version": "0.4.1",
@@ -4224,8 +4087,7 @@
     "longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "dev": true
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -4240,14 +4102,12 @@
     "markdown-table": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-      "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
-      "dev": true
+      "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw=="
     },
     "mdast-util-definitions": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
       "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -4258,7 +4118,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
       "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "escape-string-regexp": "^5.0.0",
@@ -4269,8 +4128,7 @@
         "escape-string-regexp": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-          "dev": true
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
         }
       }
     },
@@ -4278,7 +4136,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
       "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -4298,7 +4155,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz",
       "integrity": "sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0",
@@ -4309,7 +4165,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
       "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
-      "dev": true,
       "requires": {
         "mdast-util-from-markdown": "^1.0.0",
         "mdast-util-gfm-autolink-literal": "^1.0.0",
@@ -4324,7 +4179,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
       "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "ccount": "^2.0.0",
@@ -4336,7 +4190,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
       "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0",
@@ -4347,7 +4200,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
       "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0"
@@ -4357,7 +4209,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
       "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "markdown-table": "^3.0.0",
@@ -4369,7 +4220,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
       "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0"
@@ -4384,7 +4234,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
       "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "unist-util-is": "^5.0.0"
@@ -4394,7 +4243,6 @@
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
       "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
-      "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/mdast": "^3.0.0",
@@ -4410,7 +4258,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
       "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -4426,7 +4273,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
       "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0"
       }
@@ -4442,7 +4288,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
       "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
-      "dev": true,
       "requires": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -4467,7 +4312,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
       "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
-      "dev": true,
       "requires": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-factory-destination": "^1.0.0",
@@ -4491,7 +4335,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.1.1.tgz",
       "integrity": "sha512-m2UH9a7n3W8VAH9JO9y01APpPKmNNNs71P0RbknEmYSaZU5Ghogv38BYO94AI5Xw6OYfxZRdHZZ2nYjs/Z+SZQ==",
-      "dev": true,
       "requires": {
         "fault": "^2.0.0",
         "micromark-util-character": "^1.0.0",
@@ -4503,7 +4346,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
       "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
-      "dev": true,
       "requires": {
         "micromark-extension-gfm-autolink-literal": "^1.0.0",
         "micromark-extension-gfm-footnote": "^1.0.0",
@@ -4519,7 +4361,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
       "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
-      "dev": true,
       "requires": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-sanitize-uri": "^1.0.0",
@@ -4531,7 +4372,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
       "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
-      "dev": true,
       "requires": {
         "micromark-core-commonmark": "^1.0.0",
         "micromark-factory-space": "^1.0.0",
@@ -4547,7 +4387,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
       "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
-      "dev": true,
       "requires": {
         "micromark-util-chunked": "^1.0.0",
         "micromark-util-classify-character": "^1.0.0",
@@ -4561,7 +4400,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
       "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
-      "dev": true,
       "requires": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -4574,7 +4412,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
       "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
-      "dev": true,
       "requires": {
         "micromark-util-types": "^1.0.0"
       }
@@ -4583,7 +4420,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
       "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
-      "dev": true,
       "requires": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -4596,7 +4432,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
       "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
-      "dev": true,
       "requires": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
@@ -4607,7 +4442,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
       "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
-      "dev": true,
       "requires": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
@@ -4619,7 +4453,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
       "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
-      "dev": true,
       "requires": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-types": "^1.0.0"
@@ -4629,7 +4462,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
       "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
-      "dev": true,
       "requires": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -4641,7 +4473,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
       "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
-      "dev": true,
       "requires": {
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -4653,7 +4484,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
       "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
-      "dev": true,
       "requires": {
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.0"
@@ -4663,7 +4493,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
       "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
-      "dev": true,
       "requires": {
         "micromark-util-symbol": "^1.0.0"
       }
@@ -4672,7 +4501,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
       "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
-      "dev": true,
       "requires": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
@@ -4683,7 +4511,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
       "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
-      "dev": true,
       "requires": {
         "micromark-util-chunked": "^1.0.0",
         "micromark-util-types": "^1.0.0"
@@ -4693,7 +4520,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
       "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
-      "dev": true,
       "requires": {
         "micromark-util-symbol": "^1.0.0"
       }
@@ -4702,7 +4528,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
       "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
-      "dev": true,
       "requires": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^1.0.0",
@@ -4713,20 +4538,17 @@
     "micromark-util-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
-      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
-      "dev": true
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw=="
     },
     "micromark-util-html-tag-name": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
-      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
-      "dev": true
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q=="
     },
     "micromark-util-normalize-identifier": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
       "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
-      "dev": true,
       "requires": {
         "micromark-util-symbol": "^1.0.0"
       }
@@ -4735,7 +4557,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
       "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
-      "dev": true,
       "requires": {
         "micromark-util-types": "^1.0.0"
       }
@@ -4744,7 +4565,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
       "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
-      "dev": true,
       "requires": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-encode": "^1.0.0",
@@ -4755,7 +4575,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
       "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
-      "dev": true,
       "requires": {
         "micromark-util-chunked": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
@@ -4766,14 +4585,12 @@
     "micromark-util-symbol": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
-      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
-      "dev": true
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
     },
     "micromark-util-types": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
-      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
-      "dev": true
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
     },
     "micromatch": {
       "version": "4.0.5",
@@ -4799,14 +4616,12 @@
     "mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
     },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4854,7 +4669,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
       "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
       "requires": {
         "entities": "^4.4.0"
       }
@@ -4897,8 +4711,7 @@
     "property-information": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
-      "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==",
-      "dev": true
+      "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -4917,8 +4730,7 @@
     "ractive": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/ractive/-/ractive-0.7.3.tgz",
-      "integrity": "sha512-rxt5U9VTFsRaDGtwTz0+NFpUgdWEbvMSG3k1gq5YV0bco6fEo42bPqAwj0U9ivW3JdhvZ5s3YhsTYBzedesPKA==",
-      "dev": true
+      "integrity": "sha512-rxt5U9VTFsRaDGtwTz0+NFpUgdWEbvMSG3k1gq5YV0bco6fEo42bPqAwj0U9ivW3JdhvZ5s3YhsTYBzedesPKA=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -4965,7 +4777,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "dev": true,
       "requires": {
         "mri": "^1.1.0"
       }
@@ -5007,14 +4818,12 @@
     "space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
     },
     "stringify-entities": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
       "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
-      "dev": true,
       "requires": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -5074,8 +4883,7 @@
     "trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "dev": true
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
     },
     "tslib": {
       "version": "1.14.1",
@@ -5121,14 +4929,12 @@
     "unist-util-generated": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
-      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
-      "dev": true
+      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A=="
     },
     "unist-util-is": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
       "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0"
       }
@@ -5137,7 +4943,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
       "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0"
       }
@@ -5146,7 +4951,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
       "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0"
       }
@@ -5155,7 +4959,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
       "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0",
@@ -5166,7 +4969,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
       "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
@@ -5186,7 +4988,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
       "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
-      "dev": true,
       "requires": {
         "dequal": "^2.0.0",
         "diff": "^5.0.0",
@@ -5205,7 +5006,6 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
       "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -5217,7 +5017,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
       "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "vfile": "^5.0.0"
@@ -5227,7 +5026,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
       "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
-      "dev": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
@@ -5236,8 +5034,7 @@
     "web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "dev": true
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
     },
     "which": {
       "version": "2.0.2",
@@ -5273,8 +5070,7 @@
     "zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,18 @@
   "version": "1.1.0",
   "description": "Implementation of Noddity that uses Micromark and mdast to render the Markdown content, and has *no opinion* about non-Markdown content.",
   "type": "module",
-  "main": "src/index.js",
+  "module": "default/index.js",
+  "unpkg": "default/index.min.js",
+  "main": "default/index.cjs",
+  "exports": {
+    ".": {
+      "import": "./src/index.js"
+    },
+    "./legacy": {
+      "import": "./src/legacy.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "npm run lint && uvu src",
     "lint": "eslint"
@@ -30,7 +41,10 @@
   "homepage": "https://github.com/saibotsivad/noddity-micromark-renderer",
   "devDependencies": {
     "@saibotsivad/eslint-config-saibotsivad": "*",
-    "hast-util-noddity": "^1.0.0",
+    "uvu": "^0.5.6"
+  },
+  "dependencies": {
+    "hast-util-noddity": "^1.0.1",
     "hast-util-raw": "^8.0.0",
     "hast-util-sanitize": "^4.1.0",
     "hast-util-to-html": "^8.0.4",
@@ -38,13 +52,10 @@
     "mdast-util-from-markdown": "^1.3.1",
     "mdast-util-frontmatter": "^1.0.1",
     "mdast-util-gfm": "^2.0.2",
+    "mdast-util-noddity": "^1.0.2",
     "mdast-util-to-hast": "^12.3.0",
     "micromark-extension-frontmatter": "^1.1.1",
     "micromark-extension-gfm": "^2.0.3",
-    "ractive": "^0.7.3",
-    "uvu": "^0.5.6"
-  },
-  "dependencies": {
-    "mdast-util-noddity": "^1.0.2"
+    "ractive": "^0.7.3"
   }
 }

--- a/src/legacy.test.js
+++ b/src/legacy.test.js
@@ -1,0 +1,116 @@
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+
+import { sanitize } from 'hast-util-sanitize'
+import { noddityRenderer } from './legacy.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const options = {
+	directory: join(__dirname, '..', 'example', 'noddity'),
+	domain: 'site.com',
+	pathPrefix: '#!/',
+	pagePathPrefix: 'post/',
+	name: 'Legacy Test',
+	siteParam: 'original',
+}
+
+const render = noddityRenderer(options)
+
+test('rendering from a string', async () => {
+	const out = await render.fromString('a [[cool.md|file]] link', 'yolo.md')
+	assert.equal(out.html, '<p>a <a href="https://site.com/#!/post/cool.md">file</a> link</p>')
+})
+
+test('rendering a string with a template', async () => {
+	const out = await render.fromString('a ::home|cool:: template')
+	assert.equal(out.html, '<p>a <a href="https://site.com/">cool</a> template</p>')
+})
+
+test('rendering a string with a template and additional metadata', async () => {
+	const out = await render.fromString('Hello ::different::!', { site: { helloName: 'world' } })
+	assert.equal(out.html, '<p>Hello <em>world</em>!</p>')
+})
+
+test('rendering a string with a template which has a parameter', async () => {
+	const out = await render.fromString('Hello ::different|helloName=world::!')
+	assert.equal(out.html, '<p>Hello <em>world</em>!</p>')
+})
+
+test('rendering a non-markdown string and passing in site level data', async () => {
+	const out = await render.fromString('Frodo {{surname}}', { site: { surname: 'Baggins' }, metadata: { markdown: false } })
+	assert.equal(out.html, 'Frodo Baggins')
+})
+
+test('loading a file', async () => {
+	const out = await render.loadFile('example-file.md')
+	assert.equal(out.html, '<p>Here is an <a href="picture.png" target="_blank"><img src="picture.png" style="max-width:100%;"></a> and an <a href="https://site.com/#!/post/file.md">internal</a> link.</p>')
+})
+
+test('loading a file but sanitizing the html', async () => {
+	const renderWithSanitize = noddityRenderer({
+		...options,
+		hastSanitizer: hast => sanitize(hast),
+	})
+	const out = await renderWithSanitize.loadFile('example-file.md')
+	assert.equal(out.html, '<p>Here is an <a href="picture.png" target="_blank"><img src="picture.png"></a> and an <a href="https://site.com/#!/post/file.md">internal</a> link.</p>')
+})
+
+test('loading a file with older style metadata', async () => {
+	const out = await render.loadFile('old-school.md')
+	assert.equal(out.html, '<p>Notice how there are no triple dashes.\nBut it\'s still valid.</p>')
+})
+
+test('loading just some metadata', async () => {
+	const metadata = await render.loadMetadata('old-school.md')
+	assert.equal(metadata, { title: 'An Old School Noddity File' })
+})
+
+test('loading a full post', async () => {
+	const out = await render.loadPost('post', 'example-file.md')
+	assert.equal(out.html, '<div class="main-wrapper"><h1>An Example</h1> <p>Here is an <a href="picture.png" target="_blank"><img src="picture.png" style="max-width:100%;"></a> and an <a href="https://site.com/#!/post/file.md">internal</a> link.</p></div>')
+})
+
+test('you can even contort non-HTML out of it, loading a non-markdown file with additional context', async () => {
+	const out = await render.loadFile('img', {
+		site: { markdownOutput: true },
+		variables: [
+			// The exact format of `variables` will be dependent on your
+			// non-Markdown renderer implementation details. Here, of course,
+			// we are using legacy Ractive.
+			{ positional: true, name: 'picture.png' },
+			{ positional: true, name: '24em' },
+		],
+	})
+	assert.equal(out.html, '![](picture.png){width=24em}')
+})
+
+test('loading a non markdown file without any context is kind of weird but okay', async () => {
+	const out = await render.loadFile('img')
+	assert.equal(out.html, '<a target="_blank"><img style="max-width:100%;"></a>')
+})
+
+test('loading a non-markdown file with noddity in it and the hash fragment is ignored', async () => {
+	const out = await render.loadFile('html-with-noddity.md')
+	assert.equal(out.html, [
+		'<p><a href="picture.png" target="_blank"><img src="picture.png" style="max-width:100%;"></a></p>',
+		'<p><a href="https://site.com/#!/post/file.md">internal</a></p>',
+	].join('\n'))
+})
+
+test('but if we override the site context we can retain the hash fragment', async () => {
+	const renderWithoutHash = noddityRenderer({
+		...options,
+		pathPrefix: '',
+		pagePathPrefix: '',
+	})
+	const out = await renderWithoutHash.loadFile('html-with-noddity.md')
+	assert.equal(out.html, [
+		'<p><a href="picture.png" target="_blank"><img src="picture.png" style="max-width:100%;"></a></p>',
+		'<p><a href="https://site.com/file.md#header1">internal</a></p>',
+	].join('\n'))
+})
+
+test.run()

--- a/src/yaml-metadata-mdast-mutator.js
+++ b/src/yaml-metadata-mdast-mutator.js
@@ -1,0 +1,27 @@
+import { load, JSON_SCHEMA } from 'js-yaml'
+
+const SIMPLE_STYLE = /^\w+:\s\S/
+
+export const metadataMdastMutator = ({ mdastTree }) => {
+	const hasSimpleStyleMetadata = mdastTree?.children?.[0]?.type === 'paragraph'
+		&& mdastTree?.children?.[0]?.children?.length === 1
+		&& mdastTree.children[0].children[0].type === 'text'
+		&& mdastTree.children[0].children[0].value
+		&& SIMPLE_STYLE.test(mdastTree.children[0].children[0].value)
+	if (mdastTree?.children?.[0]?.type === 'yaml' || hasSimpleStyleMetadata) {
+		let value = hasSimpleStyleMetadata
+			? mdastTree.children[0].children[0].value
+			: mdastTree.children[0].value
+		try {
+			const metadata = load(value, { schema: JSON_SCHEMA })
+			if (metadata) mdastTree.children[0].metadata = metadata
+			if (hasSimpleStyleMetadata) {
+				mdastTree.children[0].type = 'yaml'
+				mdastTree.children[0].value = mdastTree.children[0].children[0].value
+				delete mdastTree.children[0].children
+			}
+		} catch (ignore) {
+			//
+		}
+	}
+}


### PR DESCRIPTION
- No longer supporting CommonJS exports, it's ✨ the future ✨ now.
- It's not bundled anymore either, as that got a bit complicated. I might bundle it again later, I realize all these dependencies are no fun to install.
